### PR TITLE
Clean up failed stacks and remove flags

### DIFF
--- a/cmd/connectme/connect/aws/cli.go
+++ b/cmd/connectme/connect/aws/cli.go
@@ -56,6 +56,8 @@ func Command() *cobra.Command {
 				name = randomname.Generate()
 			}
 
+			view.Ready()
+
 			ctx := context.Background()
 			program, err := aws.Program(name, ctx, aws.BastionArgs{
 				Name:      name,

--- a/cmd/connectme/connect/aws/cli.go
+++ b/cmd/connectme/connect/aws/cli.go
@@ -76,6 +76,7 @@ func Command() *cobra.Command {
 			stdoutStreamer := optup.ProgressStreams(outputHandler)
 			_, err = program.Up(ctx, stdoutStreamer)
 			if err != nil {
+				view.SendPulumiProgressOutput(outputHandler.CurrentProgress, "Failed to create resources. Cleaning up.", "")
 				// If the update errors, we should clean up the stack for the user.
 				_, dErr := program.Destroy(ctx)
 				if dErr != nil {

--- a/cmd/connectme/connect/aws/cli.go
+++ b/cmd/connectme/connect/aws/cli.go
@@ -89,6 +89,16 @@ func Command() *cobra.Command {
 			stdoutStreamer := optup.ProgressStreams(outputHandler)
 			_, err = program.Up(ctx, stdoutStreamer)
 			if err != nil {
+				// If the update errors, we should clean up the stack for the user.
+				_, dErr := program.Destroy(ctx)
+				if dErr != nil {
+					return fmt.Errorf("failed update: %v\n\n\tfailed clean up: %v", err, dErr)
+				}
+				rmErr := program.Workspace().RemoveStack(ctx, name)
+				if rmErr != nil {
+					return fmt.Errorf("failed update: %v\n\n\tfailed stack removal: %v", err, rmErr)
+				}
+
 				return fmt.Errorf("failed update: %v", err)
 			}
 

--- a/cmd/connectme/connect/aws/cli.go
+++ b/cmd/connectme/connect/aws/cli.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"context"
 	"fmt"
-	"net"
 
 	"github.com/jaxxstorm/connectme/pkg/aws"
 	randomname "github.com/jaxxstorm/connectme/pkg/name"
@@ -14,13 +13,11 @@ import (
 )
 
 var (
-	vpcId       string
-	region      string
-	subnetIds   []string
-	subnetRoute string
-	name        string
-	tailnet     string
-	apiKey      string
+	region    string
+	subnetIds []string
+	name      string
+	tailnet   string
+	apiKey    string
 )
 
 func Command() *cobra.Command {
@@ -30,10 +27,8 @@ func Command() *cobra.Command {
 		Long:  `Create a tailscale bastion in an AWS VPC via an autoscaling group`,
 		RunE: tui.WrapCobraCommand(func(cmd *cobra.Command, args []string, view tui.View) error {
 			// Grab all the configuration variables
-			vpcId = viper.GetString("vpcId")
 			region = viper.GetString("region")
 			subnetIds = viper.GetStringSlice("subnetIds")
-			subnetRoute = viper.GetString("route")
 			tailnet = viper.GetString("tailnet")
 			apiKey = viper.GetString("apiKey")
 			name = viper.GetString("name")
@@ -53,12 +48,6 @@ func Command() *cobra.Command {
 				return fmt.Errorf("must specify an AWS region. See --help")
 			}
 
-			// validate the IP
-			_, _, err := net.ParseCIDR(subnetRoute)
-			if err != nil {
-				return fmt.Errorf("invalid cidr: %v", err)
-			}
-
 			if err := aws.ValidateCredentials(); err != nil {
 				return fmt.Errorf("error validating AWS credentials: %v", err)
 			}
@@ -70,10 +59,8 @@ func Command() *cobra.Command {
 			ctx := context.Background()
 			program, err := aws.Program(name, ctx, aws.BastionArgs{
 				Name:      name,
-				VpcId:     vpcId,
 				SubnetIds: subnetIds,
 				Region:    region,
-				Route:     subnetRoute,
 				Tailnet:   tailnet,
 				ApiKey:    apiKey,
 			})
@@ -107,16 +94,12 @@ func Command() *cobra.Command {
 		}),
 	}
 
-	command.Flags().StringVar(&vpcId, "vpc-id", "", "The AWS Vpc Id to use.")
 	command.Flags().StringVar(&region, "region", "", "The AWS Region to use.")
 	command.Flags().StringVar(&name, "name", "", "Unique name to use for your bastion.")
-	command.Flags().StringVar(&subnetRoute, "route", "", "The subnet route to connect to. It should match your VPC Cidr.")
 	command.Flags().StringVar(&tailnet, "tailnet", "", "The name of the tailnet to connect to. See: https://login.tailscale.com/admin/settings/general")
 	command.Flags().StringVar(&apiKey, "api-key", "", "The tailnet api key to use. See: https://login.tailscale.com/admin/settings/keys")
 	command.Flags().StringSliceVar(&subnetIds, "subnet-ids", nil, "The subnet Ids to use in the Vpc.")
 
-	viper.BindPFlag("vpcId", command.Flags().Lookup("vpc-id"))
-	viper.BindPFlag("route", command.Flags().Lookup("route"))
 	viper.BindPFlag("region", command.Flags().Lookup("region"))
 	viper.BindPFlag("subnetIds", command.Flags().Lookup("subnet-ids"))
 	viper.BindPFlag("name", command.Flags().Lookup("name"))
@@ -128,9 +111,7 @@ func Command() *cobra.Command {
 	viper.BindEnv("tailnet", "TAILSCALE_TAILNET")
 	viper.BindEnv("apiKey", "TAILSCALE_API_KEY")
 
-	command.MarkFlagRequired("vpc-id")
 	command.MarkFlagRequired("subnet-ids")
-	command.MarkFlagRequired("route")
 
 	return command
 }

--- a/cmd/connectme/disconnect/aws/cli.go
+++ b/cmd/connectme/disconnect/aws/cli.go
@@ -20,6 +20,8 @@ func Command() *cobra.Command {
 		Short: "Disconnect from AWS infrastructure",
 		Long:  `Tear down a tailscale bastion in an AWS VPC via an autoscaling group`,
 		RunE: tui.WrapCobraCommand(func(cmd *cobra.Command, args []string, view tui.View) error {
+
+			view.Ready()
 			ctx := context.Background()
 			// FIXME: do we need to specify credentials here?
 			// I suspect not because I believe they're hardcoded into the provider

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/cip8/autoname v1.0.1
 	github.com/lbrlabs/pulumi-aws-tailscalebastion/sdk v0.0.2
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
+	github.com/pulumi/pulumi-aws/sdk/v5 v5.16.2
 	github.com/pulumi/pulumi/sdk/v3 v3.40.2
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/viper v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -308,6 +308,8 @@ github.com/pkg/term v1.1.0/go.mod h1:E25nymQcrSllhX42Ok8MRm1+hyBdHY0dCeiKZ9jpNGw
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/pulumi/pulumi-aws/sdk/v5 v5.16.2 h1:lPiMvKBZmZqhZ5OcM8iEb97oeX8chhtbRUskiyDeVYg=
+github.com/pulumi/pulumi-aws/sdk/v5 v5.16.2/go.mod h1:Ro2eNbpP/uGWMMvtBDrVph+jdL/G6+IiGB6kj+kDRYM=
 github.com/pulumi/pulumi/sdk/v3 v3.40.2 h1:y3ldnshfB1Hz+XrCmHkpF5igpCHepKSdvd2Mu/8xvng=
 github.com/pulumi/pulumi/sdk/v3 v3.40.2/go.mod h1:N5jL+cw5KiOeMn9bwvRuPQEAhbE3KPq2wSb/Kw+6HuY=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/pkg/aws/bastion.go
+++ b/pkg/aws/bastion.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	awstailscale "github.com/lbrlabs/pulumi-aws-tailscalebastion/sdk/go/bastion"
+	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -11,15 +12,40 @@ func Bastion(args BastionArgs) pulumi.RunFunc {
 	return func(ctx *pulumi.Context) error {
 
 		// create an array of subnets to pass to the bastion
+		var vpcId string
+		var route string
 		var subnets pulumi.StringArray
-		for _, subnet := range args.SubnetIds {
-			subnets = append(subnets, pulumi.String(subnet))
+		for _, subnetId := range args.SubnetIds {
+			subnet, err := ec2.LookupSubnet(ctx, &ec2.LookupSubnetArgs{
+				Id: pulumi.StringRef(subnetId),
+			})
+			if err != nil {
+				return fmt.Errorf("looking up subnet: %v", err)
+			}
+
+			if vpcId == "" {
+				vpcId = subnet.VpcId
+			}
+
+			if vpcId != subnet.VpcId {
+				return fmt.Errorf("all subnets must be in the same VPC")
+			}
+
+			if route == "" {
+				route = subnet.CidrBlock
+			}
+
+			if route != subnet.CidrBlock {
+				return fmt.Errorf("cidr blocks of different subnets must be identical")
+			}
+
+			subnets = append(subnets, pulumi.String(subnetId))
 		}
 
 		_, err := awstailscale.NewBastion(ctx, args.Name, &awstailscale.BastionArgs{
-			VpcId:     pulumi.String(args.VpcId),
+			VpcId:     pulumi.String(vpcId),
 			SubnetIds: subnets,
-			Route:     pulumi.String(args.Route),
+			Route:     pulumi.String(route),
 			Region:    pulumi.String(args.Region),
 		})
 

--- a/pkg/aws/types.go
+++ b/pkg/aws/types.go
@@ -2,9 +2,7 @@ package aws
 
 type BastionArgs struct {
 	Name      string
-	VpcId     string
 	SubnetIds []string
-	Route     string
 	Region    string
 	Tailnet   string
 	ApiKey    string

--- a/pkg/terminal/pulumi_output.go
+++ b/pkg/terminal/pulumi_output.go
@@ -32,7 +32,7 @@ func (i *PulumiOutput) HandleDestroy(urn, status string) {
 		i.CurrentProgress = 20
 		msg := "Destroying resources... "
 		i.Handler(20, msg, "")
-	} else if status == "deleted" {
+	} else if status == "deleted" && i.CurrentProgress < 80 {
 		i.CurrentProgress = i.CurrentProgress + 5
 		i.Handler(i.CurrentProgress, "", "")
 	}


### PR DESCRIPTION
This PR adds some clean up in case of a failure during a stack update and removes the `vpcId` & `route` flags in favor of just looking them up from the subnet id.